### PR TITLE
Fix developer section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,15 @@ Please access [https://thiagodnf.github.io/game-of-life](https://thiagodnf.githu
 
 ## For Developers
 
-Install the dependencies
+Run the development environment
+
+Clone the repository and start a simple HTTP server to serve the files locally. You can use Python for that:
 
 ```bash
-npm install
+python3 -m http.server
 ```
 
-Run the development enviroment
-
-```bash
-npm run dev
-```
+Then open <http://localhost:8000> in your browser.
 
 ## Questions or Suggestions
 


### PR DESCRIPTION
## Summary
- fix typo 'enviroment' -> 'environment'
- update dev instructions to run a local HTTP server instead of obsolete npm commands

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685363e9f9608325800c23fcaff2e846