### PR TITLE
Fix menu direction labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,8 +78,8 @@
                         <ul class="dropdown-menu" style="min-width: 200px;">
                             <li><a class="dropdown-item menubar-arrange-move" href="#" data-direction="ArrowUp"><i class="bi bi-arrow-up"></i><span>Move Up</span> <small class="float-end text-muted mt-1">Up</small> </a></li>
                             <li><a class="dropdown-item menubar-arrange-move" href="#" data-direction="ArrowDown"><i class="bi bi-arrow-down"></i><span>Move Down</span> <small class="float-end text-muted mt-1">Down</small></a></li>
-                            <li><a class="dropdown-item menubar-arrange-move" href="#" data-direction="ArrowRight"><i class="bi bi-arrow-left"></i><span>Move Right</span> <small class="float-end text-muted mt-1">Right</small></a></li>
-                            <li><a class="dropdown-item menubar-arrange-move" href="#" data-direction="ArrowLeft"><i class="bi bi-arrow-right"></i><span>Move Left</span> <small class="float-end text-muted mt-1">Left</small></a></li>
+                            <li><a class="dropdown-item menubar-arrange-move" href="#" data-direction="ArrowLeft"><i class="bi bi-arrow-left"></i><span>Move Left</span> <small class="float-end text-muted mt-1">Left</small></a></li>
+                            <li><a class="dropdown-item menubar-arrange-move" href="#" data-direction="ArrowRight"><i class="bi bi-arrow-right"></i><span>Move Right</span> <small class="float-end text-muted mt-1">Right</small></a></li>
                         </ul>
                     </li>
                     <li class="nav-item dropdown">


### PR DESCRIPTION
## Summary
- correct the Move Left and Move Right menu options so their text and data-direction match the icon

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6853661581148325a6ef3116d7ebd650