### PR TITLE
Fix CSV import handler 'this' context

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -285,7 +285,7 @@ $(function () {
         draw();
     });
 
-    $("#form-import-csv").submit(event => {
+    $("#form-import-csv").submit(function(event) {
 
         let csvFile = $(this).find("#csv-file").prop("files")[0];
 


### PR DESCRIPTION
## Summary
- fix `#form-import-csv` submission handler so `this` is the form element

## Testing
- `npx eslint .` *(fails: ESLint couldn't find config file)*

------
https://chatgpt.com/codex/tasks/task_b_6853667690c08325b698f37a0e7ca78a