### PR TITLE
Fix parseContent invalid line handling

### DIFF
--- a/js/utils/file-utils.js
+++ b/js/utils/file-utils.js
@@ -16,11 +16,22 @@ class FileUtils {
                 return;
             }
 
-            let array = rows.split(",").map(e => e.trim()).map(e => parseInt(e, 10));
+            const parts = rows.split(",").map(e => e.trim());
+
+            if (parts.length < 2) {
+                return;
+            }
+
+            const iVal = parseInt(parts[0], 10);
+            const jVal = parseInt(parts[1], 10);
+
+            if (Number.isNaN(iVal) || Number.isNaN(jVal)) {
+                return;
+            }
 
             data.push({
-                i: array[0],
-                j: array[1],
+                i: iVal,
+                j: jVal,
             });
         });
 

--- a/tests/file-utils.test.js
+++ b/tests/file-utils.test.js
@@ -26,6 +26,14 @@ describe("FileUtils.parseContent handling blanks", () => {
       { i: 2, j: 2 }
     ]);
   });
+
+  test("ignores invalid lines", () => {
+    const csv = "1,1\ninvalid\n2,2";
+    expect(FileUtils.parseContent(csv)).toEqual([
+      { i: 1, j: 1 },
+      { i: 2, j: 2 }
+    ]);
+  });
 });
 
 describe("FileUtils.readCSV", () => {


### PR DESCRIPTION
## Summary
- handle malformed rows in `parseContent`
- test ignoring invalid CSV lines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6853785c5d888325a15d6e2fff2d5d8f