### PR TITLE
Fix package entry point and license

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "game-of-life",
   "version": "1.0.0",
   "description": "<img width=\"500px\" src=\"https://user-images.githubusercontent.com/114015/178503624-8ff773c7-2ab6-4719-a195-2b6f23890e30.png\">",
-  "main": "index.js",
+  "main": "dist/bundle.js",
   "scripts": {
     "build": "rollup -c",
     "test": "jest",
@@ -10,7 +10,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary
- point `main` at the Rollup output bundle
- set package.json license to MIT

## Testing
- `npm install --legacy-peer-deps`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6853794b1c208325a9c5791663552131