### PR TITLE
Fix interval not cleared on stop

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -191,6 +191,7 @@ $(function () {
 
             start();
         } else {
+            clearInterval(intervalID);
 
             $("#startAndStop i").addClass("bi-play").removeClass("bi-stop-fill");
             $("#startAndStop span").html("Play");


### PR DESCRIPTION
## Summary
- stop the running simulation immediately by clearing the timer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68537b53d8708325953cc46aa458fc90