### PR TITLE
Fix keydown handler to only intercept arrow keys

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -283,15 +283,17 @@ $(function () {
 
     $(window).keydown(function (event) {
 
-        event.preventDefault();
-
-        if(isRunning) return;
-
         const key = event.key;
 
-        game.move(key);
+        if(["ArrowRight", "ArrowLeft", "ArrowUp", "ArrowDown"].includes(key)) {
+            event.preventDefault();
 
-        draw();
+            if(isRunning) return;
+
+            game.move(key);
+
+            draw();
+        }
     });
 
     $("#form-import-csv").submit(function(event) {


### PR DESCRIPTION
## Summary
- only block default behavior for arrow keys in the keydown handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68537b53d8708325953cc46aa458fc90