### PR TITLE
Fix duplicate cell loading bug

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -83,7 +83,7 @@ function loadPositions(positions) {
 
     for (const pos of positions) {
 
-        game.toggleCell(pos.i, pos.j);
+        game.born(new Cell(pos.i, pos.j));
     }
 
     draw();


### PR DESCRIPTION
## Summary
- ensure CSV loading doesn't toggle cells off

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68537b53d8708325953cc46aa458fc90